### PR TITLE
Add calls for source and issues urls in metadata.rb

### DIFF
--- a/templates/default/metadata.rb.erb
+++ b/templates/default/metadata.rb.erb
@@ -7,3 +7,6 @@ long_description 'Installs/Configures <%= cookbook_name %>'
 version          '0.0.1'
 
 supports 'ubuntu', '>= 12.04'
+
+source_url 'https://github.com/evertrue/<%= cookbook_name %>-cookbook' if respond_to?(:source_url)
+issues_url 'https://github.com/evertrue/<%= cookbook_name %>-cookbook/issues' if respond_to?(:issues_url)


### PR DESCRIPTION
Found this little gem in the `chef-client` cookbook.  I hate having to set those URLs in the supermarket and I hate it more then they aren't listed... so I thought this might be nice
